### PR TITLE
Remove unused font imports from layout.tsx

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,19 +1,7 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import { ThemeProvider } from "@/components/theme-provider"
 import "./globals.css";
 import "devicon/devicon.min.css";
-
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Create Next App",


### PR DESCRIPTION
This pull request simplifies the `src/app/layout.tsx` file by removing unused font imports and associated variables. These changes help streamline the file and remove unnecessary code.

Code cleanup:

* Removed the imports for `Geist` and `Geist_Mono` fonts from `next/font/google`, as well as the unused `geistSans` and `geistMono` variables. This reduces clutter and improves maintainability. (`[src/app/layout.tsxL2-L17](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L2-L17)`)